### PR TITLE
Use local phpcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ These instructions assume the use of Linux, OS X or Windows Subsystem for Linux.
 3. Install WPCS v2.3.0: `composer create-project wp-coding-standards/wpcs wpcs 2.3.0 --no-dev --prefer-dist --keep-vcs` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation)). Now, WPCS should be installed into the `wpcs` subdirectory.
 4. Clone this repository (`git clone https://github.com/ClassicPress/ClassicPress-Coding-Standards`).
 
+*If step 3 fails, you can try going on. The script will use the globally installed version of `phpcs` if there is one.*
+
 ## Usage
 
 1. Change back to your plugin-review directory (`cd /home/username/cp-plugin-review`)

--- a/bin/cpcs
+++ b/bin/cpcs
@@ -10,11 +10,23 @@ fi
 
 # wpcs needs an absolute path for installed_paths.
 WPCS_DIR="$(cd "$(dirname "$0")"; cd ../..; echo "$(pwd)/wpcs")"
+PHPCS="$WPCS_DIR/vendor/bin/phpcs"
 
-if [ ! -d "$WPCS_DIR" ] || [ ! -x "$WPCS_DIR/vendor/bin/phpcs" ]; then
+if [ ! -d "$WPCS_DIR" ]; then
 	echo "Please install WPCS into $WPCS_DIR :"
 	echo "https://github.com/WordPress/WordPress-Coding-Standards#installation"
 	exit 1
+fi
+
+if [ ! -x "$PHPCS" ]; then
+	PHPCS=`which phpcs`
+	if [ ! -x "$PHPCS" ]; then
+		echo "Please install WPCS into $WPCS_DIR :"
+		echo "https://github.com/WordPress/WordPress-Coding-Standards#installation"
+		exit 1
+	else
+		echo "Warning: using $PHPCS"
+	fi
 fi
 
 if [ -t 1 ] ; then
@@ -23,7 +35,7 @@ else
 	COLOR="--no-colors";
 fi
 
-"$WPCS_DIR/vendor/bin/phpcs" \
+"$PHPCS" \
 	$COLOR \
 	--runtime-set text_domain "$CPCS_TEXTDOMAIN" \
 	--runtime-set installed_paths "$WPCS_DIR" \


### PR DESCRIPTION
`composer create-project wp-coding-standards/wpcs wpcs 2.3.0 --no-dev --prefer-dist --keep-vcs` can fail installing `phpcs`.
But usually the necessary folder containing the sniffs is put in place. So if `phpcs` is installed globally the script tries to use that one.