### PR TITLE
Remove WordPress.WP.DeprecatedFunctions.sanitize_url

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -59,6 +59,7 @@
 		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
+		<exclude name="WordPress.WP.DeprecatedFunctions.sanitize_urlFound"/>
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.MissingVersion"/>
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion"/>
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.NotInFooter"/>


### PR DESCRIPTION
Remove `WordPress.WP.DeprecatedFunctions.sanitize_url`.

From DocBlock is now undeprecated (see this [comment](https://github.com/ClassicPress/ClassicPress-Migration-Plugin/pull/118#issuecomment-3126558555)):
```
 * @since 2.3.1
 * @since 2.8.0 Deprecated in favor of esc_url_raw().
 * @since 5.9.0 Restored (un-deprecated).
```